### PR TITLE
Improve secrets extension resolver setup

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/secrets/SecretsIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/secrets/SecretsIntegrationSpec.groovy
@@ -53,6 +53,9 @@ class SecretsIntegrationSpec extends IntegrationSpec {
 
             case "SecretKeySpecFilePathRaw":
                 return createSecretTempFilePath(rawValue as byte[])
+
+            case "DefaultResolver":
+                return "new wooga.gradle.secrets.internal.DefaultResolver(${wrapValueBasedOnType(rawValue, "Closure<String>", fallback)})"
             default:
                 return rawValue.toString()
         }

--- a/src/integrationTest/groovy/wooga/gradle/secrets/SecretsPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/secrets/SecretsPluginIntegrationSpec.groovy
@@ -16,9 +16,13 @@
 
 package wooga.gradle.secrets
 
+import com.wooga.gradle.test.ConventionSource
 import com.wooga.gradle.test.PropertyLocation
 import com.wooga.gradle.test.PropertyQueryTaskWriter
 import spock.lang.Unroll
+import wooga.gradle.secrets.internal.EnvironmentResolver
+import wooga.gradle.secrets.internal.SecretResolverChain
+import wooga.gradle.secrets.tasks.SecretsTask
 
 import static com.wooga.gradle.test.PropertyUtils.*
 import static com.wooga.gradle.test.SpecUtils.escapedPath
@@ -31,17 +35,49 @@ class SecretsPluginIntegrationSpec extends SecretsIntegrationSpec {
     }
 
     @Unroll
-    def "extension property :#property returns '#testValue' if #reason"() {
-        given: "a set value"
+    def "sets convention for task type #taskType.simpleName and property #property"() {
+        given: "write convention source assignment"
+        if (value != _) {
+            conventionSource.write(buildFile, value.toString())
+        }
 
-        fork = false
+        and: "a task to query property from"
+
+        buildFile << """
+        class ${taskType.simpleName}Impl extends ${taskType.name} {
+           //TODO this we need to adjust
+           final String errorMessage = "Failed to create/update config section"
+        }
+
+        task ${subjectUnderTestName}(type: ${taskType.simpleName}Impl)
+        """.stripIndent()
+
+        when:
+        def query = new PropertyQueryTaskWriter("${subjectUnderTestName}.${property}", pInvocation.toString())
+        query.write(buildFile)
+        def result = runTasksSuccessfully(query.taskName)
+
+        then:
+        query.matches(result, testValue)
+
+        where:
+        taskType    | property     | rawValue         | type            | conventionSource                                    | expectedValue                        | propertyInvocation
+        SecretsTask | "secretsKey" | "18273645".bytes | "SecretKeySpec" | ConventionSource.extension(extensionName, property) | _                                    | ".map({it.getEncoded()}).getOrNull()"
+        SecretsTask | "resolver"   | _                | _               | _                                                   | new SecretResolverChain().toString() | _
+
+        value = (type != _) ? wrapValueBasedOnType(rawValue, type.toString(), wrapValueFallback) : rawValue
+        testValue = (expectedValue == _) ? rawValue : expectedValue
+        pInvocation = (propertyInvocation != _) ? propertyInvocation : ".getOrNull().toString()"
+    }
+
+    private setupPropertyValue(PropertyLocation location, String invocation, String property, String value) {
         switch (location) {
             case PropertyLocation.script:
                 buildFile << "${extensionName}.${invocation}"
                 break
             case PropertyLocation.property:
                 def propertiesFile = createFile("gradle.properties")
-                propertiesFile << "${extensionName}.${property} = ${escapedValue}"
+                propertiesFile << "${extensionName}.${property} = ${(value instanceof String) ? escapedPath(value) : value}"
                 break
             case PropertyLocation.environment:
                 def envPropertyKey = envNameFromProperty(extensionName, property)
@@ -50,6 +86,12 @@ class SecretsPluginIntegrationSpec extends SecretsIntegrationSpec {
             default:
                 break
         }
+    }
+
+    @Unroll
+    def "extension property :#property returns '#testValue' if #reason"() {
+        given: "a set value"
+        setupPropertyValue(location, invocation.toString(), property.toString(), value.toString())
 
         and: "the test value with replace placeholders"
         if (testValue instanceof String) {
@@ -65,21 +107,48 @@ class SecretsPluginIntegrationSpec extends SecretsIntegrationSpec {
         query.matches(result, testValue)
 
         where:
-        property     | method                  | rawValue         | expectedValue               | type                       | location                     | propertyInvocation
-        "secretsKey" | _                       | _                | "a generated SecretKeySpec" | _                          | PropertyLocation.none        | ".map({'${expectedValue}'}).getOrNull()"
-        "secretsKey" | _                       | "18273645".bytes | _                           | "SecretKeySpecFilePathRaw" | PropertyLocation.environment | ".map({it.getEncoded()}).getOrNull()"
-        "secretsKey" | _                       | "81726354".bytes | _                           | "SecretKeySpecFilePathRaw" | PropertyLocation.property    | ".map({it.getEncoded()}).getOrNull()"
-        "secretsKey" | toSetter(property)      | "12348765".bytes | _                           | "SecretKeySpecFile"        | PropertyLocation.script      | ".map({it.getEncoded()}).getOrNull()"
-        "secretsKey" | toProviderSet(property) | "87654321".bytes | _                           | "Provider<SecretKeySpec>"  | PropertyLocation.script      | ".map({it.getEncoded()}).getOrNull()"
-        "secretsKey" | toProviderSet(property) | "12345678".bytes | _                           | "SecretKeySpec"            | PropertyLocation.script      | ".map({it.getEncoded()}).getOrNull()"
+        property         | method                  | rawValue         | expectedValue                        | type                       | location                     | propertyInvocation
+        "secretsKey"     | _                       | _                | "a generated SecretKeySpec"          | _                          | PropertyLocation.none        | ".map({'${expectedValue}'}).getOrNull()"
+        "secretsKey"     | _                       | "18273645".bytes | _                                    | "SecretKeySpecFilePathRaw" | PropertyLocation.environment | ".map({it.getEncoded()}).getOrNull()"
+        "secretsKey"     | _                       | "81726354".bytes | _                                    | "SecretKeySpecFilePathRaw" | PropertyLocation.property    | ".map({it.getEncoded()}).getOrNull()"
+        "secretsKey"     | toSetter(property)      | "12348765".bytes | _                                    | "SecretKeySpecFile"        | PropertyLocation.script      | ".map({it.getEncoded()}).getOrNull()"
+        "secretsKey"     | toProviderSet(property) | "87654321".bytes | _                                    | "Provider<SecretKeySpec>"  | PropertyLocation.script      | ".map({it.getEncoded()}).getOrNull()"
+        "secretsKey"     | toProviderSet(property) | "12345678".bytes | _                                    | "SecretKeySpec"            | PropertyLocation.script      | ".map({it.getEncoded()}).getOrNull()"
+        "secretResolver" | _                       | _                | new SecretResolverChain().toString() | _                          | PropertyLocation.none        | _
 
         value = (type != _) ? wrapValueBasedOnType(rawValue, type.toString(), wrapValueFallback) : rawValue
-        pInvocation = (propertyInvocation != _) ? propertyInvocation : ".getOrNull()"
+        pInvocation = (propertyInvocation != _) ? propertyInvocation : ".getOrNull().toString()"
         providedValue = (location == PropertyLocation.script) ? type : value
         testValue = (expectedValue == _) ? rawValue : expectedValue
         reason = location.reason() + ((location == PropertyLocation.none) ? "" : "  with '$providedValue' ")
         escapedValue = (value instanceof String) ? escapedPath(value) : value
         invocation = (method != _) ? "${method}(${escapedValue})" : "${property} = ${escapedValue}"
+    }
+
+    def "extension allows to configure resolvers in secretResolverChain with closure"() {
+        given: "an empty resolverChain"
+        buildFile << """
+        secrets.secretResolverChain.clear() 
+        """.stripIndent()
+
+        and: "configuring a new resolver"
+        buildFile << """
+        secrets.secretResolverChain {
+            add(new ${EnvironmentResolver.class.name}())
+        }
+        """.stripIndent()
+
+        when:
+        def query = new PropertyQueryTaskWriter("${extensionName}.${property}", ".getOrNull().toString()")
+        query.write(buildFile)
+        def result = runTasksSuccessfully(query.taskName)
+
+        then:
+        query.matches(result, expectedValue)
+
+        where:
+        property         | expectedValue
+        "secretResolver" | new SecretResolverChain([new EnvironmentResolver()]).toString()
     }
 
 }

--- a/src/main/groovy/wooga/gradle/secrets/BaseSpec.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/BaseSpec.groovy
@@ -19,23 +19,22 @@ package wooga.gradle.secrets
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
-import org.gradle.internal.impldep.org.eclipse.jgit.errors.NotSupportedException
 
 import javax.inject.Inject
 
 trait BaseSpec {
     @Inject
     ProjectLayout getLayout() {
-        throw new NotSupportedException("ProjectLayout is supposed to be injected here by gradle")
+        throw new Exception("ProjectLayout is supposed to be injected here by gradle")
     }
 
     @Inject
     ProviderFactory getProviderFactory() {
-        throw new NotSupportedException("")
+        throw new Exception("ProviderFactory is supposed to be injected here by gradle")
     }
 
     @Inject
     ObjectFactory getObjects() {
-        throw new NotSupportedException("")
+        throw new Exception("ObjectFactory is supposed to be injected here by gradle")
     }
 }

--- a/src/main/groovy/wooga/gradle/secrets/SecretResolverSpec.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/SecretResolverSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Wooga GmbH
+ * Copyright 2021 Wooga GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,23 @@
 
 package wooga.gradle.secrets
 
-import org.gradle.api.Action
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.util.ConfigureUtil
-import wooga.gradle.secrets.internal.SecretResolverChain
+import org.gradle.api.tasks.Input
 
-trait SecretsPluginExtension extends SecretSpec {
+trait SecretResolverSpec extends BaseSpec {
+    private final Property<SecretResolver> resolver = objects.property(SecretResolver)
 
-    abstract SecretResolverChain getSecretResolverChain()
-
-    Provider<SecretResolverChain> getSecretResolver() {
-        providerFactory.provider({ secretResolverChain })
+    @Input
+    Property<SecretResolver> getResolver() {
+        resolver
     }
 
-    void secretResolverChain(Action<SecretResolverChain> action) {
-        action.execute(secretResolverChain)
+    void setResolver(Provider<SecretResolver> value) {
+        resolver.set(value)
     }
 
-    void secretResolverChain(Closure configure) {
-        secretResolverChain(ConfigureUtil.configureUsing(configure))
+    void setResolver(SecretResolver value) {
+        resolver.set(value)
     }
 }

--- a/src/main/groovy/wooga/gradle/secrets/SecretSpec.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/SecretSpec.groovy
@@ -41,19 +41,4 @@ trait SecretSpec extends BaseSpec {
     void setSecretsKey(File keyFile) {
         setSecretsKey(new SecretKeySpec(keyFile.bytes, "AES"))
     }
-
-    private final Property<SecretResolver> secretResolver = objects.property(SecretResolver)
-
-    @Input
-    Property<SecretResolver> getSecretResolver() {
-        secretResolver
-    }
-
-    void setSecretResolver(Provider<SecretResolver> value) {
-        secretResolver.set(value)
-    }
-
-    void setSecretResolver(SecretResolver value) {
-        secretResolver.set(value)
-    }
 }

--- a/src/main/groovy/wooga/gradle/secrets/SecretsPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/SecretsPlugin.groovy
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.RandomStringUtils
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import wooga.gradle.secrets.internal.DefaultSecretsPluginExtension
+import wooga.gradle.secrets.internal.EnvironmentResolver
 import wooga.gradle.secrets.tasks.SecretsTask
 
 import javax.crypto.SecretKeyFactory
@@ -44,7 +45,7 @@ class SecretsPlugin implements Plugin<Project> {
 
     protected static SecretsPluginExtension create_and_configure_extension(Project project) {
         def extension = project.extensions.create(SecretsPluginExtension, EXTENSION_NAME, DefaultSecretsPluginExtension)
-        extension.secretsKey.convention(SecretsConsts.SECRETS_KEY.getFileValueProvider(project).map({new SecretKeySpec(it.asFile.bytes, "AES")}).orElse(project.provider({
+        extension.secretsKey.convention(SecretsConsts.SECRETS_KEY.getFileValueProvider(project).map({ new SecretKeySpec(it.asFile.bytes, "AES") }).orElse(project.provider({
             KeySpec spec = new PBEKeySpec(secretsKeyPassword().chars, secretsKeySalt(), SecretsConsts.SECRETS_KEY_ITERATION, SecretsConsts.SECRETS_KEY_LENGTH);
             // AES-256
             SecretKeyFactory f = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");

--- a/src/main/groovy/wooga/gradle/secrets/internal/DefaultSecretsPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/internal/DefaultSecretsPluginExtension.groovy
@@ -20,4 +20,5 @@ package wooga.gradle.secrets.internal
 import wooga.gradle.secrets.SecretsPluginExtension
 
 class DefaultSecretsPluginExtension implements SecretsPluginExtension {
+    final SecretResolverChain secretResolverChain = new SecretResolverChain()
 }

--- a/src/main/groovy/wooga/gradle/secrets/internal/EnvironmentResolver.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/internal/EnvironmentResolver.groovy
@@ -24,15 +24,21 @@ class EnvironmentResolver implements SecretResolver {
     @Override
     Secret resolve(String secretId) {
         String secret = System.getenv(secretId.toUpperCase())
-        if(!secret) {
+        if (!secret) {
             throw new SecretResolverException("Unable to resolve secret with id ${secretId}")
         }
 
         def f = new File(secret)
-        if(f.exists()) {
+        if (f.exists()) {
             return new DefaultSecret(f.bytes)
         }
 
         new DefaultSecret(secret)
+    }
+
+
+    @Override
+    String toString() {
+        "EnvironmentResolver"
     }
 }

--- a/src/main/groovy/wooga/gradle/secrets/internal/SecretResolverChain.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/internal/SecretResolverChain.groovy
@@ -45,26 +45,34 @@ class SecretResolverChain implements SecretResolver, List<SecretResolver> {
 
     @Override
     Secret<?> resolve(String secretId) {
-        if(empty) {
+        if (empty) {
             throw new SecretResolverException("No secret resolvers configured.")
         }
 
         Secret secret = null
 
-        for(SecretResolver resolver in resolverChain) {
+        for (SecretResolver resolver in resolverChain) {
             try {
                 secret = resolver.resolve(secretId)
-                if(secret) {
+                if (secret) {
                     break
                 }
             }
-            catch(SecretResolverException ignored) {}
+            catch (SecretResolverException ignored) {
+            }
         }
 
-        if(!secret) {
+        if (!secret) {
             throw new SecretResolverException("Unable to resolve secret with id ${secretId}")
         }
 
         secret
+    }
+
+    @Override
+    String toString() {
+        "SecretResolverChain{" +
+                "resolverChain=" + resolverChain +
+                '}'
     }
 }

--- a/src/main/groovy/wooga/gradle/secrets/tasks/SecretsTask.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/tasks/SecretsTask.groovy
@@ -17,7 +17,8 @@
 package wooga.gradle.secrets.tasks
 
 import org.gradle.api.DefaultTask
+import wooga.gradle.secrets.SecretResolverSpec
 import wooga.gradle.secrets.SecretSpec
 
-abstract class SecretsTask extends DefaultTask implements SecretSpec {
+abstract class SecretsTask extends DefaultTask implements SecretSpec, SecretResolverSpec {
 }


### PR DESCRIPTION
## Description

I made the decission to remove the resolver provider from the secrets extension in favior of setting up a new resolver:

```groovy
final SecretResolverChain secretResolverChain = new SecretResolverChain()
```

This in combination with two configuration helper methods and a provider wrapper for convention assignments makes it easier for the user to configure the resolver:

```groovy
Provider<SecretResolverChain> getSecretResolver() {
    providerFactory.provider({ secretResolverChain })
}

void secretResolverChain(Action<SecretResolverChain> action) {
    action.execute(secretResolverChain)
}

void secretResolverChain(Closure configure) {
    secretResolverChain(ConfigureUtil.configureUsing(configure))
}
```

In most cases one needs one or several resolvers which are linked in a chain anyways. This also means that there is a default resolver already setup. To configure the chain one can use the configuration helpers.

```groovy
secrets.secretResolverChain {
    clear()
    add(new EnvironmentResolver())
}
```

## Changes

* ![IMPROVE] secrets extension resolver setup
* ![BREAK] remove `resolver` property in secrets extension
* ![ADD] `secretsResolverChain` in secrets extension


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
