### PR TITLE
Add Provider API method for secret values in secrets extension

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/secrets/SecretsPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/secrets/SecretsPluginIntegrationSpec.groovy
@@ -20,6 +20,7 @@ import com.wooga.gradle.test.ConventionSource
 import com.wooga.gradle.test.PropertyLocation
 import com.wooga.gradle.test.PropertyQueryTaskWriter
 import spock.lang.Unroll
+import wooga.gradle.secrets.internal.DefaultResolver
 import wooga.gradle.secrets.internal.EnvironmentResolver
 import wooga.gradle.secrets.internal.SecretResolverChain
 import wooga.gradle.secrets.tasks.SecretsTask
@@ -149,6 +150,26 @@ class SecretsPluginIntegrationSpec extends SecretsIntegrationSpec {
         where:
         property         | expectedValue
         "secretResolver" | new SecretResolverChain([new EnvironmentResolver()]).toString()
+    }
+
+    def "extension resolves secrets wrapped in provider"() {
+        given: "a resolver chain with a default resolver configured"
+        buildFile << """
+        secrets.secretResolverChain {
+            add(new ${DefaultResolver.class.name}({ String secretId ->
+                switch(secretId) {
+                    case "secretString":
+                        return "a secret value"
+                    break
+                    case "secretFile":
+                        return "a secret value".bytes
+                    break
+                }
+            }))
+        }
+        """.stripIndent()
+
+
     }
 
 }

--- a/src/main/groovy/wooga/gradle/secrets/SecretResolver.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/SecretResolver.groovy
@@ -17,6 +17,6 @@
 package wooga.gradle.secrets
 
 interface SecretResolver<T> {
-    Secret<T> resolve(String secretId)
+    Secret<T> resolve(String secretId) throws SecretResolverException
 }
 

--- a/src/test/groovy/wooga/gradle/secrets/SecretsPluginExtensionSpec.groovy
+++ b/src/test/groovy/wooga/gradle/secrets/SecretsPluginExtensionSpec.groovy
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2021 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.secrets
+
+import nebula.test.ProjectSpec
+import wooga.gradle.secrets.internal.DefaultSecret
+
+class SecretsPluginExtensionSpec extends ProjectSpec {
+    public static final String PLUGIN_NAME = 'net.wooga.secrets'
+
+    SecretsPluginExtension subjectUnderTest
+    def resolver = Mock(SecretResolver)
+
+    def setup() {
+        project.plugins.apply(PLUGIN_NAME)
+        subjectUnderTest = project.extensions.findByName('secrets') as SecretsPluginExtension
+        subjectUnderTest.secretResolverChain.add(resolver)
+    }
+
+    def "secretValue resolves secrets wrapped in Provider<String>"() {
+        given: "a mock resolver"
+        resolver.resolve(secretId) >> new DefaultSecret(expectedValue)
+
+        when:
+        def secret = subjectUnderTest.secretValue(secretId)
+
+        then:
+        noExceptionThrown()
+        secret != null
+        secret.present
+        secret.get() == expectedValue
+
+        where:
+        secretId      | expectedValue
+        "some_secret" | "some secret value"
+    }
+
+    def "secretFileAsBytes resolves secrets wrapped in Provider<byte[]>"() {
+        given: "a mock resolver"
+        resolver.resolve(secretId) >> new DefaultSecret(expectedValue)
+
+        when:
+        def secret = subjectUnderTest.secretFileAsBytes(secretId)
+
+        then:
+        noExceptionThrown()
+        secret != null
+        secret.present
+        secret.get() == expectedValue
+
+        where:
+        secretId      | expectedValue
+        "some_secret" | "some secret value".bytes
+    }
+
+    def "secretFile resolves secrets wrapped in Provider<RegularFile>"() {
+        given: "a mock resolver"
+        resolver.resolve(secretId) >> new DefaultSecret(expectedValue)
+
+        when:
+        def secret = subjectUnderTest.secretFile(secretId)
+
+        then:
+        noExceptionThrown()
+        secret != null
+        secret.present
+        secret.get().asFile.getBytes() == expectedValue
+
+        where:
+        secretId      | expectedValue
+        "some_secret" | "some secret value".bytes
+    }
+
+    def "secretValue throws no exceptions when secret can not be found"() {
+        given: "a mock resolver"
+        resolver.resolve(_) >> { secretId -> throw new SecretResolverException("Unable to resolve secret with id ${secretId}") }
+
+        when:
+        def present = subjectUnderTest.secretValue("some secret").isPresent()
+
+        then:
+        noExceptionThrown()
+        !present
+    }
+
+    def "secretValue throws no exceptions when secret is of wrong type"() {
+        given: "a mock resolver"
+        def resolver = Mock(SecretResolver)
+        resolver.resolve(_) >> new DefaultSecret<byte[]>("some value".bytes)
+
+        when:
+        def present = subjectUnderTest.secretValue("some secret").isPresent()
+
+        then:
+        noExceptionThrown()
+        !present
+    }
+
+    def "secretFileAsBytes throws no exceptions when secret can not be found"() {
+        given: "a mock resolver"
+        resolver.resolve(_) >> { secretId -> throw new SecretResolverException("Unable to resolve secret with id ${secretId}") }
+
+        when:
+        def present = subjectUnderTest.secretFileAsBytes("some secret").isPresent()
+
+        then:
+        noExceptionThrown()
+        !present
+    }
+
+    def "secretFileAsBytes throws no exceptions when secret is of wrong type"() {
+        given: "a mock resolver"
+        resolver.resolve(_) >> new DefaultSecret<String>("some value")
+
+        when:
+        def present = subjectUnderTest.secretFileAsBytes("some secret").isPresent()
+
+        then:
+        noExceptionThrown()
+        !present
+    }
+
+    def "secretFile throws no exceptions when secret can not be found"() {
+        given: "a mock resolver"
+        resolver.resolve(_) >> { secretId -> throw new SecretResolverException("Unable to resolve secret with id ${secretId}") }
+
+        when:
+        subjectUnderTest.secretFile("some secret").isPresent()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "secretFile throws no exceptions when secret is of wrong type"() {
+        given: "a mock resolver"
+        resolver.resolve(_) >> new DefaultSecret<String>("some value")
+
+        when:
+        def present = subjectUnderTest.secretFile("some secret").isPresent()
+
+        then:
+        noExceptionThrown()
+        !present
+    }
+}


### PR DESCRIPTION
## Description

I added three new methods in the `SecretPluginExtension` trait to help work with secrets which needs to passed down as values to `Provider<String>` or `Provider<RegularFile>`.

```groovy
Provider<String> secretValue(String secretId)
Provider<byte[]> secretFileAsBytes(String secretId)
Provider<RegularFile> secretFile(String secretId)
```

These methods map the configured resolver chain and lazily fetch secrets when the provider requests the secret value. All exceptions from the resolver will be caught so to keep the Provider clean and save to use without exceptions. I opted for a simple warning message to the log. The exception handling in a Provider chain is not really clear to me.

## Changes

* ![ADD] Provider API methods for secret values in secrets extension


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
