### PR TITLE
Revert secretResolver setter in secrets extension

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/secrets/SecretsIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/secrets/SecretsIntegrationSpec.groovy
@@ -17,6 +17,8 @@
 package wooga.gradle.secrets
 
 import com.wooga.gradle.test.IntegrationSpec
+import wooga.gradle.secrets.internal.DefaultResolver
+import wooga.gradle.secrets.internal.EnvironmentResolver
 import wooga.gradle.secrets.tasks.SecretsTask
 
 class SecretsIntegrationSpec extends IntegrationSpec {
@@ -55,7 +57,9 @@ class SecretsIntegrationSpec extends IntegrationSpec {
                 return createSecretTempFilePath(rawValue as byte[])
 
             case "DefaultResolver":
-                return "new wooga.gradle.secrets.internal.DefaultResolver(${wrapValueBasedOnType(rawValue, "Closure<String>", fallback)})"
+                return "new ${DefaultResolver.class.name}(${wrapValueBasedOnType(rawValue, "Closure<String>", fallback)})"
+            case "EnvironmentResolver":
+                return "new ${EnvironmentResolver.class.name}()"
             default:
                 return rawValue.toString()
         }

--- a/src/integrationTest/groovy/wooga/gradle/secrets/SecretsPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/secrets/SecretsPluginIntegrationSpec.groovy
@@ -108,14 +108,15 @@ class SecretsPluginIntegrationSpec extends SecretsIntegrationSpec {
         query.matches(result, testValue)
 
         where:
-        property         | method                  | rawValue         | expectedValue                        | type                       | location                     | propertyInvocation
-        "secretsKey"     | _                       | _                | "a generated SecretKeySpec"          | _                          | PropertyLocation.none        | ".map({'${expectedValue}'}).getOrNull()"
-        "secretsKey"     | _                       | "18273645".bytes | _                                    | "SecretKeySpecFilePathRaw" | PropertyLocation.environment | ".map({it.getEncoded()}).getOrNull()"
-        "secretsKey"     | _                       | "81726354".bytes | _                                    | "SecretKeySpecFilePathRaw" | PropertyLocation.property    | ".map({it.getEncoded()}).getOrNull()"
-        "secretsKey"     | toSetter(property)      | "12348765".bytes | _                                    | "SecretKeySpecFile"        | PropertyLocation.script      | ".map({it.getEncoded()}).getOrNull()"
-        "secretsKey"     | toProviderSet(property) | "87654321".bytes | _                                    | "Provider<SecretKeySpec>"  | PropertyLocation.script      | ".map({it.getEncoded()}).getOrNull()"
-        "secretsKey"     | toProviderSet(property) | "12345678".bytes | _                                    | "SecretKeySpec"            | PropertyLocation.script      | ".map({it.getEncoded()}).getOrNull()"
-        "secretResolver" | _                       | _                | new SecretResolverChain().toString() | _                          | PropertyLocation.none        | _
+        property         | method                  | rawValue         | expectedValue                                                   | type                       | location                     | propertyInvocation
+        "secretsKey"     | _                       | _                | "a generated SecretKeySpec"                                     | _                          | PropertyLocation.none        | ".map({'${expectedValue}'}).getOrNull()"
+        "secretsKey"     | _                       | "18273645".bytes | _                                                               | "SecretKeySpecFilePathRaw" | PropertyLocation.environment | ".map({it.getEncoded()}).getOrNull()"
+        "secretsKey"     | _                       | "81726354".bytes | _                                                               | "SecretKeySpecFilePathRaw" | PropertyLocation.property    | ".map({it.getEncoded()}).getOrNull()"
+        "secretsKey"     | toSetter(property)      | "12348765".bytes | _                                                               | "SecretKeySpecFile"        | PropertyLocation.script      | ".map({it.getEncoded()}).getOrNull()"
+        "secretsKey"     | toProviderSet(property) | "87654321".bytes | _                                                               | "Provider<SecretKeySpec>"  | PropertyLocation.script      | ".map({it.getEncoded()}).getOrNull()"
+        "secretsKey"     | toProviderSet(property) | "12345678".bytes | _                                                               | "SecretKeySpec"            | PropertyLocation.script      | ".map({it.getEncoded()}).getOrNull()"
+        "secretResolver" | _                       | _                | new SecretResolverChain().toString()                            | _                          | PropertyLocation.none        | _
+        "secretResolver" | toSetter(property)      | _                | new SecretResolverChain([new EnvironmentResolver()]).toString() | "EnvironmentResolver"      | PropertyLocation.script      | _
 
         value = (type != _) ? wrapValueBasedOnType(rawValue, type.toString(), wrapValueFallback) : rawValue
         pInvocation = (propertyInvocation != _) ? propertyInvocation : ".getOrNull().toString()"

--- a/src/main/groovy/wooga/gradle/secrets/SecretsPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/SecretsPluginExtension.groovy
@@ -21,8 +21,9 @@ import org.gradle.api.Action
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.util.ConfigureUtil
-import java.util.logging.Logger
 import wooga.gradle.secrets.internal.SecretResolverChain
+
+import java.util.logging.Logger
 
 trait SecretsPluginExtension extends SecretSpec {
 
@@ -44,6 +45,10 @@ trait SecretsPluginExtension extends SecretSpec {
 
     void secretResolverChain(Closure configure) {
         secretResolverChain(ConfigureUtil.configureUsing(configure))
+    }
+
+    void setSecretResolver(SecretResolver resolver) {
+        secretResolverChain.setResolverChain(resolver)
     }
 
     Provider<String> secretValue(String secretId) {


### PR DESCRIPTION
## Description

In patch [#294] I removed a setter in the secrets extension to set the secret resolver. Since we use a default resolver chain I thought we don't need this setter anymore. I checked with most of the projects implementing this plugin and I saw that this setter is used a lot and would actually make upgrade a lot harder. In the end I decided to revert this decision and add it in again. It will basically clear the chain and set a single resolver. That was from the old behavior the same so nothing actually changes here in API usage

## Changes

* ![ADD] `setSecretResolver` setter in secrets extension




[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
