### PR TITLE
Fix small issues with the changed gradle property parameters

### DIFF
--- a/src/main/groovy/wooga/gradle/secrets/SecretResolverSpec.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/SecretResolverSpec.groovy
@@ -19,11 +19,12 @@ package wooga.gradle.secrets
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 
 trait SecretResolverSpec extends BaseSpec {
     private final Property<SecretResolver> resolver = objects.property(SecretResolver)
 
-    @Input
+    @Internal
     Property<SecretResolver> getResolver() {
         resolver
     }

--- a/src/main/groovy/wooga/gradle/secrets/SecretSpec.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/SecretSpec.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.secrets
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 
 import javax.crypto.spec.SecretKeySpec
 
@@ -26,6 +27,7 @@ trait SecretSpec extends BaseSpec {
     private final Property<SecretKeySpec> secretsKey = objects.property(SecretKeySpec)
 
     @Input
+    @Optional
     Property<SecretKeySpec> getSecretsKey() {
         secretsKey
     }


### PR DESCRIPTION
## Description

During the process of refactoring the SecuritySpec I made an error and defined the `secretResolver` property as an input even though it should only be an internal property. The `secretsKey` property also should be `Optional`.

## Changes

* ![FIX] gradle property parameters after refactoring


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
