### PR TITLE
Add secret resolver factory methods to secrets extension

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/secrets/SecretsPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/secrets/SecretsPluginIntegrationSpec.groovy
@@ -169,8 +169,6 @@ class SecretsPluginIntegrationSpec extends SecretsIntegrationSpec {
             }))
         }
         """.stripIndent()
-
-
     }
 
 }

--- a/src/main/groovy/wooga/gradle/secrets/SecretResolverFactory.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/SecretResolverFactory.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.secrets
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.profiles.ProfileFile
+import software.amazon.awssdk.regions.Region
+import wooga.gradle.secrets.internal.AWSSecretsManagerResolver
+import wooga.gradle.secrets.internal.EnvironmentResolver
+import wooga.gradle.secrets.internal.SecretResolverChain
+
+trait SecretResolverFactory {
+    SecretResolver awsSecretResolver(AwsCredentialsProvider credentials, Region region) {
+        new AWSSecretsManagerResolver(credentials, region)
+    }
+
+    SecretResolver awsSecretResolver(String profileName, Region region) {
+        new AWSSecretsManagerResolver(awsCredentialsProvider(profileName), region)
+    }
+
+    SecretResolver awsSecretResolver(Region region) {
+        new AWSSecretsManagerResolver(region)
+    }
+
+    SecretResolver environmentResolver() {
+        new EnvironmentResolver()
+    }
+
+    SecretResolver chainResolver(SecretResolver... resolvers) {
+        chainResolver(resolvers.toList())
+    }
+
+    SecretResolver chainResolver(Iterable<SecretResolver> resolvers) {
+        new SecretResolverChain(resolvers)
+    }
+
+    AwsCredentialsProvider awsCredentialsProvider(String profileName) {
+        awsCredentialsProvider(profileName, ProfileFile.defaultProfileFile())
+    }
+
+    AwsCredentialsProvider awsCredentialsProvider(String profileName, ProfileFile profileFile) {
+        DefaultCredentialsProvider.builder().profileFile(profileFile).profileName(profileName).build()
+    }
+}

--- a/src/main/groovy/wooga/gradle/secrets/SecretsPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/SecretsPlugin.groovy
@@ -20,7 +20,6 @@ import org.apache.commons.lang3.RandomStringUtils
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import wooga.gradle.secrets.internal.DefaultSecretsPluginExtension
-import wooga.gradle.secrets.internal.EnvironmentResolver
 import wooga.gradle.secrets.tasks.SecretsTask
 
 import javax.crypto.SecretKeyFactory

--- a/src/main/groovy/wooga/gradle/secrets/SecretsPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/SecretsPluginExtension.groovy
@@ -25,7 +25,7 @@ import wooga.gradle.secrets.internal.SecretResolverChain
 
 import java.util.logging.Logger
 
-trait SecretsPluginExtension extends SecretSpec {
+trait SecretsPluginExtension implements SecretSpec, SecretResolverFactory {
 
     static Logger LOGGER = Logger.getLogger(SecretsPluginExtension.class.getName());
 
@@ -91,4 +91,5 @@ trait SecretsPluginExtension extends SecretSpec {
             tempFile
         }))
     }
+
 }


### PR DESCRIPTION
## Description

This patch adds factory methods for the internal secret resolver classes. This allows to create these resolvers without exporting the internal classes and their constructors etc to the public API.

The provided API for this is behind a traid `SecretResolverFactory`

I also added two helper methods to create AwsCredentialsProvider objects.

```groovy
SecretResolver awsSecretResolver(AwsCredentialsProvider credentials, Region region)
SecretResolver awsSecretResolver(String profileName, Region region)
SecretResolver awsSecretResolver(Region region)
SecretResolver environmentResolver()
SecretResolver chainResolver(SecretResolver... resolvers)
SecretResolver chainResolver(Iterable<SecretResolver> resolvers)
AwsCredentialsProvider awsCredentialsProvider(String profileName)
AwsCredentialsProvider awsCredentialsProvider(String profileName, ProfileFile profileFile)
```

## Changes

* ![ADD] `SecretResolverFactory` methods to secrets extension


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
f