### PR TITLE
Improve API usage of SecretResolveChain in secrets extension

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/secrets/SecretsPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/secrets/SecretsPluginIntegrationSpec.groovy
@@ -153,6 +153,32 @@ class SecretsPluginIntegrationSpec extends SecretsIntegrationSpec {
         "secretResolver" | new SecretResolverChain([new EnvironmentResolver()]).toString()
     }
 
+    def "extension allows to configure resolvers in secretResolverChain with closure and factory methods"() {
+        given: "an empty resolverChain"
+        buildFile << """
+        secrets.secretResolverChain.clear()
+        """.stripIndent()
+
+        and: "configuring a new resolver"
+        buildFile << """
+        secrets.secretResolverChain {
+            add(environmentResolver())
+        }
+        """.stripIndent()
+
+        when:
+        def query = new PropertyQueryTaskWriter("${extensionName}.${property}", ".getOrNull().toString()")
+        query.write(buildFile)
+        def result = runTasksSuccessfully(query.taskName)
+
+        then:
+        query.matches(result, expectedValue)
+
+        where:
+        property         | expectedValue
+        "secretResolver" | new SecretResolverChain([new EnvironmentResolver()]).toString()
+    }
+
     def "extension resolves secrets wrapped in provider"() {
         given: "a resolver chain with a default resolver configured"
         buildFile << """

--- a/src/main/groovy/wooga/gradle/secrets/SecretResolverFactory.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/SecretResolverFactory.groovy
@@ -29,12 +29,28 @@ trait SecretResolverFactory {
         new AWSSecretsManagerResolver(credentials, region)
     }
 
+    SecretResolver awsSecretResolver(AwsCredentialsProvider credentials, String region) {
+        new AWSSecretsManagerResolver(credentials, Region.of(region))
+    }
+
     SecretResolver awsSecretResolver(String profileName, Region region) {
         new AWSSecretsManagerResolver(awsCredentialsProvider(profileName), region)
     }
 
+    SecretResolver awsSecretResolver(String profileName, String region) {
+        new AWSSecretsManagerResolver(awsCredentialsProvider(profileName), Region.of(region))
+    }
+
     SecretResolver awsSecretResolver(Region region) {
         new AWSSecretsManagerResolver(region)
+    }
+
+    SecretResolver awsSecretResolver(String region) {
+        new AWSSecretsManagerResolver(Region.of(region))
+    }
+
+    SecretResolver awsSecretResolver() {
+        new AWSSecretsManagerResolver()
     }
 
     SecretResolver environmentResolver() {

--- a/src/main/groovy/wooga/gradle/secrets/SecretsPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/SecretsPluginExtension.groovy
@@ -51,7 +51,13 @@ trait SecretsPluginExtension implements SecretSpec, SecretResolverFactory {
         secretResolverChain.setResolverChain(resolver)
     }
 
+
+    @Deprecated
     Provider<String> secretValue(String secretId) {
+       secretText(secretId)
+    }
+
+    Provider<String> secretText(String secretId) {
         secretResolver.map({ SecretResolver resolver ->
             try {
                 def resolvedValue = resolver.resolve(secretId).getSecretValue()

--- a/src/main/groovy/wooga/gradle/secrets/internal/AWSSecretsManagerResolver.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/internal/AWSSecretsManagerResolver.groovy
@@ -42,6 +42,10 @@ class AWSSecretsManagerResolver implements SecretResolver {
         this(SecretsManagerClient.builder().region(region).build())
     }
 
+    AWSSecretsManagerResolver() {
+        this(SecretsManagerClient.create())
+    }
+
     @Override
     Secret<?> resolve(String secretId) {
         GetSecretValueRequest request = GetSecretValueRequest.builder().secretId(secretId).build() as GetSecretValueRequest

--- a/src/main/groovy/wooga/gradle/secrets/internal/SecretResolverChain.groovy
+++ b/src/main/groovy/wooga/gradle/secrets/internal/SecretResolverChain.groovy
@@ -19,8 +19,9 @@ package wooga.gradle.secrets.internal
 import wooga.gradle.secrets.Secret
 import wooga.gradle.secrets.SecretResolver
 import wooga.gradle.secrets.SecretResolverException
+import wooga.gradle.secrets.SecretResolverFactory
 
-class SecretResolverChain implements SecretResolver, List<SecretResolver> {
+class SecretResolverChain implements SecretResolver, List<SecretResolver>, SecretResolverFactory {
 
     @Delegate
     private final List<SecretResolver> resolverChain

--- a/src/test/groovy/wooga/gradle/secrets/SecretsPluginExtensionSpec.groovy
+++ b/src/test/groovy/wooga/gradle/secrets/SecretsPluginExtensionSpec.groovy
@@ -174,6 +174,15 @@ class SecretsPluginExtensionSpec extends ProjectSpec {
         SecretResolver.class.isAssignableFrom(resolver.class)
     }
 
+    def "security resolver factory method awsSecretResolver with region as String creates resolver"() {
+        when:
+        def resolver = subjectUnderTest.awsSecretResolver(Region.US_EAST_1.id())
+
+        then:
+        resolver != null
+        SecretResolver.class.isAssignableFrom(resolver.class)
+    }
+
     def "security resolver factory method awsSecretResolver with profileName and region creates resolver"() {
         when:
         def resolver = subjectUnderTest.awsSecretResolver("some_profile", Region.US_EAST_1)
@@ -183,9 +192,38 @@ class SecretsPluginExtensionSpec extends ProjectSpec {
         SecretResolver.class.isAssignableFrom(resolver.class)
     }
 
+    def "security resolver factory method awsSecretResolver with profileName and region as String creates resolver"() {
+        when:
+        def resolver = subjectUnderTest.awsSecretResolver("some_profile", Region.US_EAST_1.id())
+
+        then:
+        resolver != null
+        SecretResolver.class.isAssignableFrom(resolver.class)
+    }
+
     def "security resolver factory method awsSecretResolver with credentials provider and region creates resolver"() {
         when:
         def resolver = subjectUnderTest.awsSecretResolver(DefaultCredentialsProvider.builder().build(), Region.US_EAST_1)
+
+        then:
+        resolver != null
+        SecretResolver.class.isAssignableFrom(resolver.class)
+    }
+
+    def "security resolver factory method awsSecretResolver without arguments creates resolver"() {
+        given: "an aws region configured (Otherwise aws raises an exception)"
+        environmentVariables.set("AWS_REGION", Region.US_EAST_1.id())
+        when:
+        def resolver = subjectUnderTest.awsSecretResolver()
+
+        then:
+        resolver != null
+        SecretResolver.class.isAssignableFrom(resolver.class)
+    }
+
+    def "security resolver factory method awsSecretResolver with credentials provider and region as String creates resolver"() {
+        when:
+        def resolver = subjectUnderTest.awsSecretResolver(DefaultCredentialsProvider.builder().build(), Region.US_EAST_1.id())
 
         then:
         resolver != null


### PR DESCRIPTION
## Description

The initial idea of configuring resolvers for the global resolver was to declare a static chain in the `secrets` extension and use the `List` interface to be able to `add`,`remove` resolver.

```groovy
secrets.secretResolverChain {
    add(new wooga.gradle.secrets.internal.EnvironmentResolver())
}
```

I don't want to see imports or calls to `new` in `build.gradle` files.The last patch also brought in the `SecretResolverFactory` which was geared towards this specific usecase. I thought that a construct like:

```groovy
secrets.secretResolverChain {
    add(secrets.environmentResolver())
}
```

But this leads to scoping issues because the call with a closure is not actually running like groovy would execute a clojure with `with` for example. Means that the passed closure can't see the secrets extension or the project. Which means that it can't reach the factory method in the extension.

Because the `SecretResolverFactory` is a simple standalone `trait` object I'm able to implement into any class. So I did just that and added the `trait` to the `SecretResolverChain`. This allows now to configure the chain resolver like this:

```groovy
secrets.secretResolverChain {
    add(environmentResolver())
}
```

I think that is a nice and simple solution. After this I took another look at the `SecretResolverFactory` and decided to add some more overloads to pass the aws region as `String`.

```groovy
secrets.secretResolverChain {
    add((awsSecretResolver("eu-west-2"))
}
```

This just helps to reduce friction for simple configurations.

Changes
=======

* ![IMPROVE] `SecretResolverChain` API with implemented `SecretResolverFactory` trait
* ![ADD] `secretText(String secretId)` method to extension
* ![IMPROVE] `Deprecate` method `secretValue(String secretId). Will be removed with `1.0.0` release




[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
