### PR TITLE
Upgrade to gradle-commons 1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '2.2.2'
+    id 'net.wooga.plugins' version '2.2.4'
 }
 
 group 'net.wooga.gradle'
@@ -49,5 +49,5 @@ dependencies {
     api 'software.amazon.awssdk:secretsmanager:(2.16,3]'
     implementation "org.yaml:snakeyaml:1.26"
     implementation 'org.apache.commons:commons-text:1.8'
-    implementation 'com.wooga.gradle:gradle-commons:0.2.0'
+    implementation 'com.wooga.gradle:gradle-commons:[1,2)'
 }


### PR DESCRIPTION
## Description

Upgrades to latest gradle-commons.

## Changes
* ![UPDATE] Upgrade to `gradle-commons` `1`
* ![UPDATE] Upgrade to `plugins`  `2.2.4` since it was not building anymore (grgit issues)

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
