### PR TITLE
Update apache-commons-text to latest 1.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,6 @@ dependencies {
     // https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-project-gradle.html
     api 'software.amazon.awssdk:secretsmanager:(2.16,3]'
     implementation "org.yaml:snakeyaml:1.26"
-    implementation 'org.apache.commons:commons-text:1.8'
+    implementation 'org.apache.commons:commons-text:[1.10,2['
     implementation 'com.wooga.gradle:gradle-commons:[1,2['
 }

--- a/build.gradle
+++ b/build.gradle
@@ -53,8 +53,8 @@ dependencies {
     testImplementation 'com.wooga.gradle:gradle-commons-test:[1,2['
 
     // https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-project-gradle.html
-    api 'software.amazon.awssdk:secretsmanager:(2.16,3]'
-    implementation "org.yaml:snakeyaml:1.26"
+    api 'software.amazon.awssdk:secretsmanager:(2.16,3['
+    implementation "org.yaml:snakeyaml:[1.31,2["
     implementation 'org.apache.commons:commons-text:[1.10,2['
     implementation 'com.wooga.gradle:gradle-commons:[1,2['
 }


### PR DESCRIPTION
## Description
`org.apache.commons:commons-text` was pinned to the ancient 1.8, which had a vulnerability solved in 1.10. Now we support a range from 1.10 to 2.

`org.yaml:snakeyaml` was pinned to 1.26, which has a vulnerability that was solved in 1.31. Now we use the `[1.31,2[` version range for it. 

## Changes
* ![UPDATE] `org.apache.commons:commons-text` to `[1.10, 2[`
* ![UPDATE] `org.yaml:snakeyaml` to `[1.31, 2[`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
